### PR TITLE
Revert "John tutorial branch"

### DIFF
--- a/shopping.txt
+++ b/shopping.txt
@@ -1,14 +1,11 @@
-Milk (Own brand)
+Milk (Cravendale)
 Eggs
 Bread
-Yoghurt (Müller)
-Sugar (Own brand)
-Flour (Wholemeal)
+Yoghurt (Rachels)
+Sugar (Tate and Lyle)
+Flour
 Tomatoes
 Broccoli
 Carrots
 Beef mince (Irish)
 Soy sauce
-Tea (English Breakfast)
-Bananas
-Red wine


### PR DESCRIPTION
Reverts Financial-Times/git-playpen#2 – as this should have been approved by someone else. 
